### PR TITLE
(download_to_file) fixed: ArgumentError: wrong number of arguments

### DIFF
--- a/lib/google_drive/file.rb
+++ b/lib/google_drive/file.rb
@@ -96,7 +96,7 @@ module GoogleDrive
     def download_to_file(path, params = {})
       @session.drive_service.get_file(
         id,
-        { download_dest: path, supports_all_drives: true }.merge(params)
+        **{ download_dest: path, supports_all_drives: true }.merge(params)
       )
     end
 


### PR DESCRIPTION
 (given 2, expected 1) on Ruby3