### PR TITLE
Escape single quotes in sheet names.

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -385,7 +385,7 @@ module GoogleDrive
       api_spreadsheet =
         @session.sheets_service.get_spreadsheet(
           spreadsheet.id,
-          ranges: "'%s'" % @title,
+          ranges: "'%s'" % @title.gsub("'"){"''"},
           fields:
             'sheets(properties,data.rowData.values' \
             '(formattedValue,userEnteredValue,effectiveValue))'
@@ -681,7 +681,7 @@ module GoogleDrive
       response =
           @session.sheets_service.get_spreadsheet(
               spreadsheet.id,
-              ranges: "'%s'" % @remote_title,
+              ranges: "'%s'" % @remote_title.gsub("'"){"''"},
               fields: 'sheets.data.rowData.values(formattedValue,userEnteredValue,effectiveValue)'
           )
       update_cells_from_api_sheet(response.sheets[0])


### PR DESCRIPTION
This avoids a bad request error returned by Google API Client when sheet name has unbalanced single quotes.